### PR TITLE
chore: Restore vite.config.js for GitHub Pages deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/TH_Site/',
+  build: {
+    // Explicitly disable Server-Side Rendering
+    ssr: false,
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
This commit restores the original `vite.config.js` file. The `base` property is essential for ensuring that the project builds correctly for deployment on GitHub Pages, as it sets the correct asset path for the production build.